### PR TITLE
Deleted dependence_deploy, it was needed when we were using Helm 2 (a…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,10 +94,6 @@ resource "helm_release" "helloworld" {
       var.cluster_domain_name,
     )
   })]
-
-  depends_on = [
-    var.dependence_deploy
-  ]
 }
 
 resource "helm_release" "multi_container_app" {
@@ -120,9 +116,4 @@ resource "helm_release" "multi_container_app" {
     postgres-enabled = var.enable_postgres_container
     postgres-secret  = var.enable_postgres_container ? "postgresurl-secret" : var.rds_secret
   })]
-
-  depends_on = [
-    var.dependence_deploy
-  ]
-
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-variable "dependence_deploy" {
-  description = "Deploy Module dependence in order to be executed (deploy resource is the helm init)"
-}
-
 variable "enable_starter_pack" {
   type        = bool
   default     = true


### PR DESCRIPTION
`dependence_deploy` variable was needed when we were using Helm 2, it was the way to tell Helm Chart inside our terraform modules to wait for tiller before getting installed.

Now we are using Helm 3 and there is not tiller in the clusters.