### PR TITLE
Override PostgreSQL image settings to use Bitnami Legacy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,5 +119,24 @@ resource "helm_release" "multi_container_app" {
       value = var.enable_postgres_container ? "postgresurl-secret" : var.rds_secret
     }
   ]
+
+  set = [
+    {
+      name  = "postgresql.image.registry"
+      value = "docker.io"
+    },
+    {
+      name  = "postgresql.image.repository"
+      value = "bitnamilegacy/postgresql"
+    },
+    {
+      name  = "postgresql.image.tag"
+      value = "11.2.0-debian-9-r49"
+    },
+    {
+      name  = "postgresql.global.security.allowInsecureImages"
+      value = "true"
+    }
+  ]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -131,7 +131,7 @@ resource "helm_release" "multi_container_app" {
     },
     {
       name  = "postgresql.image.tag"
-      value = "11.2.0-debian-9-r49"
+      value = "11.8.0"
     },
     {
       name  = "postgresql.global.security.allowInsecureImages"


### PR DESCRIPTION
As part of the move to Bitnami legacy, the multi-container-app Helm resource was edited to override non-legacy values to legacy. AllowInsecureImages was also set to true (to ignore the insecure image message).